### PR TITLE
msm8974-oppo: Adjust persistent RAM address

### DIFF
--- a/arch/arm/mach-msm/oppo/board-8974-oppo.c
+++ b/arch/arm/mach-msm/oppo/board-8974-oppo.c
@@ -66,7 +66,7 @@ static struct persistent_ram_descriptor msm_prd[] __initdata = {
 static struct persistent_ram msm_pr __initdata = {
 	.descs = msm_prd,
 	.num_descs = ARRAY_SIZE(msm_prd),
-	.start = PLAT_PHYS_OFFSET + SZ_1G + SZ_512M,
+	.start = PLAT_PHYS_OFFSET + SZ_1G + SZ_256M,
 	.size = SZ_1M,
 };
 


### PR DESCRIPTION
 * For compatibility with new batch of hardware.

Change-Id: Ifa82916578fa28fdab66f3795cc54e8fe7fa4158